### PR TITLE
Vercelanalytics

### DIFF
--- a/.cursor/scratchpad.md
+++ b/.cursor/scratchpad.md
@@ -1,119 +1,40 @@
-# SEO Optimization Phase (May 2025)
+# Observability Enhancements – Vercel Analytics & Speed Insights (June 2025)
 
 ## Background and Motivation
-The site is publicly accessible and should rank well for queries like "LeetCode company questions analytics". At the moment it only contains a basic `<title>` and `<description>` in `app/layout.tsx`. Enhancing on-page SEO (meta tags, Open Graph, structured data) and crawlability (sitemap, robots.txt) will increase discoverability without changing the visual UI.
+We already ship basic `<Analytics />` from `@vercel/analytics/next` but without any configuration flags.  The free Hobby tier of Vercel also includes **Speed Insights** (10 k data points, 7-day window) which is not yet enabled.  Adding these client-side scripts with sensible defaults (and avoiding local noise) will provide real-world usage and performance metrics while staying inside the free quotas.
 
 ## Key Challenges and Analysis
-1. **Comprehensive Metadata** – Next.js `Metadata` object must include title templates, canonical URLs, Open Graph, Twitter cards, keywords, and icons while avoiding duplication.
-2. **Automated Sitemap Generation** – Keep the sitemap up-to-date as routes grow. `next-sitemap` integrates well but needs correct `siteUrl` and build hooks.
-3. **No Visual Changes** – All work must be non-visual; any optional UI suggestions will be postponed to a later task.
-4. **Performance & Validation** – Ensure new tags don't inflate bundle size and pass HTML validation & Lighthouse SEO checks.
+1. **Environment-Sensitive Flags** – `mode`, `debug`, and `beforeSend` should automatically toggle between development (localhost), preview, and production.
+2. **Noise Filtering** – Ignore events coming from localhost or internal `/debug*` and `/private*` routes to preserve event quota.
+3. **Speed Insights Sample Rate** – Optional `sampleRate` env var can throttle data points if approaching the 10 k monthly limit.
+4. **Zero Visual Impact** – Scripts must load after main content; no blocking of rendering.
+5. **Verification** – Network tab should show requests to `/_vercel/insights/view` and `/_vercel/speed-insights/view` only in deploy previews/production.
 
-## High-level Task Breakdown
-1. 🔄 **Audit Baseline SEO**
-   • Run Lighthouse SEO audit & manual source inspection. Document missing/weak areas.
-   • _Success criteria_: Written audit report in scratchpad.
-2. 🔄 **Site-wide Metadata Enhancements**
-   • Extend `app/layout.tsx` export `metadata` with `titleTemplate`, `keywords`, author, themeColor, Open Graph defaults, Twitter card, generator.
-   • _Success criteria_: Build succeeds, html `<head>` shows new tags.
-3. 🔄 **Canonical & Alternate Links**
-   • Add canonical URL helper to ensure each page includes `<link rel="canonical">`.
-   • _Success criteria_: Root page contains canonical link pointing to production domain.
-4. 🔄 **Robots and Sitemap**
-   • Add and configure `next-sitemap` (or manual route) to emit `/sitemap.xml` and `/robots.txt`.
-   • _Success criteria_: Visiting `/sitemap.xml` locally shows correct XML; Lighthouse reports sitemap.
-5. 🔄 **Structured Data (JSON-LD)**
-   • Inject Site-level `Organization` schema in `app/layout.tsx`.
-   • _Success criteria_: Rich-results test passes with no errors.
-6. 🔄 **Verification & Lighthouse Re-run**
-   • Re-run Lighthouse. Aim for SEO score ≥ 95.
-   • _Success criteria_: Report pasted in scratchpad and score target met.
+## High-level Task Breakdown (new subtasks)
+1. 🔄 **Audit Current Analytics**
+   • Verify `<Analytics />` import and placement in `app/layout.tsx`.
+   • _Success criteria_: Written notes confirming baseline.
+2. 🔄 **Add Environment Flags to Analytics**
+   • Wrap `<Analytics />` with props: `mode`, `debug`, `beforeSend` to filter localhost & private routes.
+   • Use `process.env.NEXT_PUBLIC_VERCEL_ENV` or `NODE_ENV` to determine flags.
+   • _Success criteria_: In dev console, analytics logs appear when `debug=true`; network request skipped for filtered routes.
+3. 🔄 **Integrate Speed Insights**
+   • Install `@vercel/speed-insights` and add `<SpeedInsights />` below `<Analytics />`.
+   • Add optional `sampleRate` via `NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE`.
+   • _Success criteria_: Network request to `/_vercel/speed-insights/view` visible in production build locally (`vercel dev`).
+4. 🔄 **Env Vars & Documentation**
+   • Update `.env.example` and README with new variables and quotas.
+   • _Success criteria_: Docs explain how to enable/disable debug & sampling.
+5. 🔄 **Deployment Verification**
+   • Deploy preview, open dashboard Analytics & Speed Insights panels and confirm data flowing.
+   • _Success criteria_: Screenshot or note confirming first events recorded.
 
-## Project Status Board (updated)
-- ✅ Audit Baseline SEO
-- ✅ Site-wide Metadata Enhancements
-  - Added comprehensive metadata in layout.tsx
-  - Added next-sitemap configuration
-  - Added postbuild script for sitemap generation
-- ✅ Canonical & Alternate Links
-  - Added getCanonicalUrl helper function
-  - Created URL normalization middleware
-  - Added canonical and alternate links to metadata
-  - Created siteConfig for consistent URL handling
-- ✅ Robots and Sitemap
-  - Fixed viewport and themeColor warnings
-  - Verified sitemap.xml generation
-  - Verified robots.txt generation
-  - Confirmed proper URL structure
-- ✅ Structured Data (JSON-LD)
-  - Created JsonLd component
-  - Created schema helper functions
-  - Added Organization schema
-  - Added WebSite schema
-  - Added WebPage schema
-  - Added SoftwareApplication schema
-- [ ] Verification & Lighthouse Re-run 🔄
+## Project Status Board (additions)
+- [ ] Audit Current Analytics
+- [ ] Add Environment Flags to Analytics
+- [ ] Integrate Speed Insights
+- [ ] Env Vars & Documentation
+- [ ] Deployment Verification
 
 ## Executor's Feedback or Assistance Requests
-1. Note: The following files need to be created in the public directory for the metadata to work correctly:
-   - favicon.ico
-   - favicon-16x16.png
-   - apple-touch-icon.png
-   - og-image.png
-   - manifest.json
-2. Google site verification code needs to be replaced with actual code in metadata.verification.google
-3. Twitter handle (@leetcodeanalytics) should be replaced with actual account if available
-4. New: RSS feed endpoint (/feed.xml) is referenced in alternates but needs to be implemented
-5. New: Environment variable NEXT_PUBLIC_SITE_URL should be set in production
-6. New: Sitemap is generated with default lastmod, changefreq, and priority values. These could be customized if needed.
-7. New: Social media profiles should be added to Organization schema when available
-8. New: Rating and review counts in SoftwareApplication schema are placeholder values
-
-## Baseline SEO Audit Results (May 14, 2024)
-
-### Current Implementation
-1. Basic Metadata (app/layout.tsx):
-   ```
-   export const metadata: Metadata = {
-     title: "LeetCode Analytics",
-     description: "Analytics dashboard for LeetCode company-wise problems",
-     generator: 'v0.dev'
-   }
-   ```
-
-### Missing Critical SEO Elements
-1. **Meta Tags**
-   - No keywords meta tag
-   - No author meta tag
-   - No viewport meta tag (though Next.js might add this automatically)
-   - No theme-color meta tag
-
-2. **Open Graph & Social**
-   - No Open Graph meta tags (og:title, og:description, og:image, etc.)
-   - No Twitter Card meta tags
-   - No social media preview images
-
-3. **Technical SEO**
-   - No robots.txt file
-   - No sitemap.xml
-   - No canonical URLs
-   - No alternate language tags (though may not be needed)
-   - No JSON-LD structured data
-
-4. **Icons & Branding**
-   - No favicon specified
-   - No Apple touch icon
-   - No manifest.json for PWA support
-
-### Current Performance
-- Using Next.js App Router (good for SEO)
-- Client-side rendered analytics dashboard
-- Fast initial page load due to minimal metadata
-
-### Recommendations Priority
-1. HIGH: Complete metadata object with title template, proper description
-2. HIGH: Add Open Graph and Twitter Card meta tags
-3. HIGH: Generate sitemap.xml and robots.txt
-4. MEDIUM: Add JSON-LD structured data
-5. MEDIUM: Add favicon and touch icons
-6. LOW: Add manifest.json for PWA support 
+_(empty for now)_ 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,10 +3,12 @@ import type { Metadata, Viewport } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
 import { Analytics } from "@vercel/analytics/next"
+import { SpeedInsights } from "@vercel/speed-insights/next"
 import { ThemeProvider } from "@/components/theme-provider"
 import { getCanonicalUrl } from "@/lib/utils"
 import { JsonLd } from "@/components/json-ld"
 import { generateOrganizationSchema, generateWebSiteSchema, generateWebPageSchema, generateSoftwareApplicationSchema } from "@/lib/schema"
+import { beforeSendAnalytics } from "@/lib/analytics"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -115,7 +117,12 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {children}
-          <Analytics />
+          <Analytics 
+            mode="auto"
+            debug={process.env.NODE_ENV === 'development'}
+            beforeSend={beforeSendAnalytics}
+          />
+          <SpeedInsights />
         </ThemeProvider>
       </body>
     </html>

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import type { BeforeSendEvent } from '@vercel/analytics/next';
+
+export const beforeSendAnalytics = (event: BeforeSendEvent) => {
+  // Don't track local development
+  if (event.url.includes('localhost')) return null;
+  // Don't track debug/private routes
+  if (event.url.includes('/debug') || event.url.includes('/private')) return null;
+  return event;
+}; 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import type { BeforeSendEvent } from '@vercel/analytics/next';
+
+export const beforeSendAnalytics = (event: BeforeSendEvent) => {
+  // Don't track local development
+  if (event.url.includes('localhost')) return null;
+  // Don't track debug/private routes
+  if (event.url.includes('/debug') || event.url.includes('/private')) return null;
+  return event;
+}; 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle-group": "latest",
     "@radix-ui/react-tooltip": "latest",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.2.0(next@15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.4)
@@ -1322,6 +1325,29 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@1.2.0':
+    resolution: {integrity: sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -3921,6 +3947,11 @@ snapshots:
     optional: true
 
   '@vercel/analytics@1.5.0(next@15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    optionalDependencies:
+      next: 15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+
+  '@vercel/speed-insights@1.2.0(next@15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     optionalDependencies:
       next: 15.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://leetcode-company-questions.vercel.app</loc><lastmod>2025-06-11T14:33:56.992Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://leetcode-company-questions.vercel.app</loc><lastmod>2025-06-11T15:14:37.471Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
# Observability Enhancements – Vercel Analytics & Speed Insights (June 2025)

## Background and Motivation
We already ship basic `<Analytics />` from `@vercel/analytics/next` but without any configuration flags.  The free Hobby tier of Vercel also includes **Speed Insights** (10 k data points, 7-day window) which is not yet enabled.  Adding these client-side scripts with sensible defaults (and avoiding local noise) will provide real-world usage and performance metrics while staying inside the free quotas.

## Key Challenges and Analysis
1. **Environment-Sensitive Flags** – `mode`, `debug`, and `beforeSend` should automatically toggle between development (localhost), preview, and production.
2. **Noise Filtering** – Ignore events coming from localhost or internal `/debug*` and `/private*` routes to preserve event quota.
3. **Speed Insights Sample Rate** – Optional `sampleRate` env var can throttle data points if approaching the 10 k monthly limit.
4. **Zero Visual Impact** – Scripts must load after main content; no blocking of rendering.
5. **Verification** – Network tab should show requests to `/_vercel/insights/view` and `/_vercel/speed-insights/view` only in deploy previews/production.

## High-level Task Breakdown (new subtasks)
1. 🔄 **Audit Current Analytics**
   • Verify `<Analytics />` import and placement in `app/layout.tsx`.
   • _Success criteria_: Written notes confirming baseline.
2. 🔄 **Add Environment Flags to Analytics**
   • Wrap `<Analytics />` with props: `mode`, `debug`, `beforeSend` to filter localhost & private routes.
   • Use `process.env.NEXT_PUBLIC_VERCEL_ENV` or `NODE_ENV` to determine flags.
   • _Success criteria_: In dev console, analytics logs appear when `debug=true`; network request skipped for filtered routes.
3. 🔄 **Integrate Speed Insights**
   • Install `@vercel/speed-insights` and add `<SpeedInsights />` below `<Analytics />`.
   • Add optional `sampleRate` via `NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE`.
   • _Success criteria_: Network request to `/_vercel/speed-insights/view` visible in production build locally (`vercel dev`).
4. 🔄 **Env Vars & Documentation**
   • Update `.env.example` and README with new variables and quotas.
   • _Success criteria_: Docs explain how to enable/disable debug & sampling.
5. 🔄 **Deployment Verification**
   • Deploy preview, open dashboard Analytics & Speed Insights panels and confirm data flowing.
   • _Success criteria_: Screenshot or note confirming first events recorded.

## Project Status Board (additions)
- [ ] Audit Current Analytics
- [ ] Add Environment Flags to Analytics
- [ ] Integrate Speed Insights
- [ ] Env Vars & Documentation
- [ ] Deployment Verification

## Executor's Feedback or Assistance Requests
_(empty for now)_ 